### PR TITLE
Fixed URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sendria
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/enthus-golang/sendria.svg)](https://pkg.go.dev/github.com/enthus-golang/sendria)
-[![CI](https://github.com/enthus-golang/sendria/actions/workflows/ci.yml/badge.svg)](https://github.com/enthus-golang/sendria/actions/workflows/ci.yml)
+[![CI](https://github.com/enthus-golang/sendria/actions/workflows/go.yml/badge.svg)](https://github.com/enthus-golang/sendria/actions/workflows/go.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/enthus-golang/sendria)](https://goreportcard.com/report/github.com/enthus-golang/sendria)
 [![codecov](https://codecov.io/gh/enthus-golang/sendria/branch/main/graph/badge.svg)](https://codecov.io/gh/enthus-golang/sendria)
 [![License](https://img.shields.io/github/license/enthus-golang/sendria)](https://github.com/enthus-golang/sendria/blob/main/LICENSE)


### PR DESCRIPTION
This pull request updates the CI badge in the `README.md` file to reflect the correct workflow configuration.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Changed the CI badge link from `ci.yml` to `go.yml` to align with the updated workflow file for CI processes.